### PR TITLE
Add cache to Travis CI to improve build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ node_js:
 cache:
   directories:
   - node_modules
-before_script:
-- npm i
 script:
 - npm test
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: node_js
 node_js:
 - node
 - '8'
+cache:
+  directories:
+  - node_modules
 before_script:
 - npm i
 script:


### PR DESCRIPTION
Cache the `node_modules` directory to improve build time of Travis.